### PR TITLE
Check inside_interval_mask before computing splines

### DIFF
--- a/nde/transforms/splines/cubic.py
+++ b/nde/transforms/splines/cubic.py
@@ -36,19 +36,20 @@ def unconstrained_cubic_spline(inputs,
     else:
         raise RuntimeError('{} tails are not implemented.'.format(tails))
 
-    outputs[inside_interval_mask], logabsdet[inside_interval_mask] = cubic_spline(
-        inputs=inputs[inside_interval_mask],
-        unnormalized_widths=unnormalized_widths[inside_interval_mask, :],
-        unnormalized_heights=unnormalized_heights[inside_interval_mask, :],
-        unnorm_derivatives_left=unnorm_derivatives_left[inside_interval_mask, :],
-        unnorm_derivatives_right=unnorm_derivatives_right[inside_interval_mask, :],
-        inverse=inverse,
-        left=-tail_bound, right=tail_bound, bottom=-tail_bound, top=tail_bound,
-        min_bin_width=min_bin_width,
-        min_bin_height=min_bin_height,
-        eps=eps,
-        quadratic_threshold=quadratic_threshold
-    )
+    if torch.any(inside_interval_mask):
+        outputs[inside_interval_mask], logabsdet[inside_interval_mask] = cubic_spline(
+            inputs=inputs[inside_interval_mask],
+            unnormalized_widths=unnormalized_widths[inside_interval_mask, :],
+            unnormalized_heights=unnormalized_heights[inside_interval_mask, :],
+            unnorm_derivatives_left=unnorm_derivatives_left[inside_interval_mask, :],
+            unnorm_derivatives_right=unnorm_derivatives_right[inside_interval_mask, :],
+            inverse=inverse,
+            left=-tail_bound, right=tail_bound, bottom=-tail_bound, top=tail_bound,
+            min_bin_width=min_bin_width,
+            min_bin_height=min_bin_height,
+            eps=eps,
+            quadratic_threshold=quadratic_threshold
+        )
 
     return outputs, logabsdet
 

--- a/nde/transforms/splines/linear.py
+++ b/nde/transforms/splines/linear.py
@@ -23,12 +23,13 @@ def unconstrained_linear_spline(inputs, unnormalized_pdf,
     else:
         raise RuntimeError('{} tails are not implemented.'.format(tails))
 
-    outputs[inside_interval_mask], logabsdet[inside_interval_mask] = linear_spline(
-        inputs=inputs[inside_interval_mask],
-        unnormalized_pdf=unnormalized_pdf[inside_interval_mask, :],
-        inverse=inverse,
-        left=-tail_bound, right=tail_bound, bottom=-tail_bound, top=tail_bound
-    )
+    if torch.any(inside_interval_mask):
+        outputs[inside_interval_mask], logabsdet[inside_interval_mask] = linear_spline(
+            inputs=inputs[inside_interval_mask],
+            unnormalized_pdf=unnormalized_pdf[inside_interval_mask, :],
+            inverse=inverse,
+            left=-tail_bound, right=tail_bound, bottom=-tail_bound, top=tail_bound
+        )
 
     return outputs, logabsdet
 

--- a/nde/transforms/splines/quadratic.py
+++ b/nde/transforms/splines/quadratic.py
@@ -33,15 +33,16 @@ def unconstrained_quadratic_spline(inputs,
     else:
         raise RuntimeError('{} tails are not implemented.'.format(tails))
 
-    outputs[inside_interval_mask], logabsdet[inside_interval_mask] = quadratic_spline(
-        inputs=inputs[inside_interval_mask],
-        unnormalized_widths=unnormalized_widths[inside_interval_mask, :],
-        unnormalized_heights=unnormalized_heights[inside_interval_mask, :],
-        inverse=inverse,
-        left=-tail_bound, right=tail_bound, bottom=-tail_bound, top=tail_bound,
-        min_bin_width=min_bin_width,
-        min_bin_height=min_bin_height
-    )
+    if torch.any(inside_interval_mask):
+        outputs[inside_interval_mask], logabsdet[inside_interval_mask] = quadratic_spline(
+            inputs=inputs[inside_interval_mask],
+            unnormalized_widths=unnormalized_widths[inside_interval_mask, :],
+            unnormalized_heights=unnormalized_heights[inside_interval_mask, :],
+            inverse=inverse,
+            left=-tail_bound, right=tail_bound, bottom=-tail_bound, top=tail_bound,
+            min_bin_width=min_bin_width,
+            min_bin_height=min_bin_height
+        )
 
     return outputs, logabsdet
 

--- a/nde/transforms/splines/rational_quadratic.py
+++ b/nde/transforms/splines/rational_quadratic.py
@@ -37,17 +37,18 @@ def unconstrained_rational_quadratic_spline(inputs,
     else:
         raise RuntimeError('{} tails are not implemented.'.format(tails))
 
-    outputs[inside_interval_mask], logabsdet[inside_interval_mask] = rational_quadratic_spline(
-        inputs=inputs[inside_interval_mask],
-        unnormalized_widths=unnormalized_widths[inside_interval_mask, :],
-        unnormalized_heights=unnormalized_heights[inside_interval_mask, :],
-        unnormalized_derivatives=unnormalized_derivatives[inside_interval_mask, :],
-        inverse=inverse,
-        left=-tail_bound, right=tail_bound, bottom=-tail_bound, top=tail_bound,
-        min_bin_width=min_bin_width,
-        min_bin_height=min_bin_height,
-        min_derivative=min_derivative
-    )
+    if torch.any(inside_interval_mask):
+        outputs[inside_interval_mask], logabsdet[inside_interval_mask] = rational_quadratic_spline(
+            inputs=inputs[inside_interval_mask],
+            unnormalized_widths=unnormalized_widths[inside_interval_mask, :],
+            unnormalized_heights=unnormalized_heights[inside_interval_mask, :],
+            unnormalized_derivatives=unnormalized_derivatives[inside_interval_mask, :],
+            inverse=inverse,
+            left=-tail_bound, right=tail_bound, bottom=-tail_bound, top=tail_bound,
+            min_bin_width=min_bin_width,
+            min_bin_height=min_bin_height,
+            min_derivative=min_derivative
+        )
 
     return outputs, logabsdet
 


### PR DESCRIPTION
In the (rare) event that there are no points inside the spline interval,
computing a spline crashes because it assumes implicitly that the
interval contains points (e.g. via use of `min()`). This patch fixes
this behaviour.